### PR TITLE
Magic paragraphs that are inserted on click near certain block elements

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -50,6 +50,7 @@ import { WoltlabBbcode } from "./plugins/ckeditor5-woltlab-bbcode";
 import { WoltlabBlockQuote } from "./plugins/ckeditor5-woltlab-block-quote";
 import { WoltlabCode } from "./plugins/ckeditor5-woltlab-code";
 import { WoltlabCodeBlock } from "./plugins/ckeditor5-woltlab-code-block";
+import { WoltlabMagicParagraph } from "./plugins/ckeditor5-woltlab-magic-paragraph";
 import { WoltlabMedia } from "./plugins/ckeditor5-woltlab-media";
 import { WoltlabMention } from "./plugins/ckeditor5-woltlab-mention";
 import { WoltlabMetacode } from "./plugins/ckeditor5-woltlab-metacode";
@@ -110,6 +111,7 @@ const defaultConfig: EditorConfig = {
     WoltlabBbcode,
     WoltlabCode,
     WoltlabCodeBlock,
+    WoltlabMagicParagraph,
     WoltlabMedia,
     WoltlabMention,
     WoltlabMetacode,

--- a/plugins/ckeditor5-woltlab-magic-paragraph/package.json
+++ b/plugins/ckeditor5-woltlab-magic-paragraph/package.json
@@ -1,0 +1,6 @@
+{
+  "author": "WoltLab GmbH",
+  "license": "LGPL-2.1-or-later",
+  "main": "src/index.ts",
+  "private": true
+}

--- a/plugins/ckeditor5-woltlab-magic-paragraph/src/index.ts
+++ b/plugins/ckeditor5-woltlab-magic-paragraph/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @author Alexander Ebert
+ * @copyright 2001-2023 WoltLab GmbH
+ * @license LGPL-2.1-or-later
+ * @since 6.0
+ */
+
+export { WoltlabMagicParagraph } from "./woltlabmagicparagraph";

--- a/plugins/ckeditor5-woltlab-magic-paragraph/src/woltlabmagicparagraph.ts
+++ b/plugins/ckeditor5-woltlab-magic-paragraph/src/woltlabmagicparagraph.ts
@@ -1,6 +1,8 @@
 /**
- * Inserts extra buttons for BBCodes into the toolbar. Buttons have support for
- * Font Awesome icons through the `<fa-icon>` element.
+ * Listens for clicks in the editor that occur within the margin of certain
+ * block elements as well as clicks at the very beginning or end of the editor.
+ * If such a click is detected and there is no paragraph at that location then
+ * a paragraph will implicitly be injected and the caret is being moved into it.
  *
  * @author Alexander Ebert
  * @copyright 2001-2023 WoltLab GmbH
@@ -24,110 +26,102 @@ export class WoltlabMagicParagraph extends Plugin {
   }
 
   init() {
-    this.editor.editing.view.addObserver(ClickObserver);
+    const { mapper, view } = this.editor.editing;
+    const { document, domConverter } = view;
 
-    const viewDocument = this.editor.editing.view.document;
+    view.addObserver(ClickObserver);
 
-    this.listenTo<ViewDocumentClickEvent>(
-      viewDocument,
-      "click",
-      (event, data) => {
-        console.clear();
+    this.listenTo<ViewDocumentClickEvent>(document, "click", (event, data) => {
+      console.clear();
 
-        const { domEvent, domTarget, target } = data;
+      const { domEvent, target } = data;
 
-        // Ignore any click that hits a paragraph or list item, because those
-        // are perfectly accessible anyway.
-        const elements = target.getAncestors();
-        elements.push(target);
-        for (const element of elements) {
-          if (element.is("element", "p") || element.is("element", "li")) {
-            return;
-          }
-        }
-
-        const { clientY } = domEvent;
-        const { domConverter } = this.editor.editing.view;
-
-        // Check if the click occurred before the first element or after the
-        // last element. These elements do not have a margin thus they would
-        // fail to detect in the margin hit check below.
-        const root = this.editor.editing.view.document.getRoot()!;
-        const firstChild = root.getChild(0);
-        if (firstChild === undefined) {
+      // Ignore any click that hits a paragraph or list item, because those
+      // are perfectly accessible anyway.
+      const elements = target.getAncestors();
+      elements.push(target);
+      for (const element of elements) {
+        if (element.is("element", "p") || element.is("element", "li")) {
           return;
         }
+      }
 
-        if (firstChild.is("containerElement")) {
-          const model = this.editor.editing.mapper.toModelElement(firstChild);
-          if (model && WoltlabMagicParagraph.blockModels.includes(model.name)) {
-            const domElement = domConverter.mapViewToDom(firstChild)!;
-            const { top } = domElement?.getBoundingClientRect();
+      const { clientY } = domEvent;
 
-            if (clientY <= top) {
-              event.stop();
+      // Check if the click occurred before the first element or after the
+      // last element. These elements do not have a margin thus they would
+      // fail to detect in the margin hit check below.
+      const root = document.getRoot()!;
+      const firstChild = root.getChild(0);
+      if (firstChild === undefined) {
+        return;
+      }
 
-              this.#insertParagraphBefore(firstChild);
-              return;
-            }
-          }
-        }
+      if (firstChild.is("containerElement")) {
+        const model = mapper.toModelElement(firstChild);
+        if (model && WoltlabMagicParagraph.blockModels.includes(model.name)) {
+          const domElement = domConverter.mapViewToDom(firstChild)!;
+          const { top } = domElement.getBoundingClientRect();
 
-        if (root.childCount > 1) {
-          const lastChild = root.getChild(root.childCount - 1)!;
-
-          if (lastChild.is("containerElement")) {
-            const model = this.editor.editing.mapper.toModelElement(lastChild);
-            if (
-              model &&
-              WoltlabMagicParagraph.blockModels.includes(model.name)
-            ) {
-              const domElement = domConverter.mapViewToDom(lastChild)!;
-              const { bottom } = domElement?.getBoundingClientRect();
-
-              if (clientY >= bottom) {
-                event.stop();
-
-                this.#insertParagraphAfter(lastChild);
-                return;
-              }
-            }
-          }
-        }
-
-        // Find any block element whose margin is possibly being clicked on.
-        for (const candidate of this.#findPossibleBlocks()) {
-          const domElement = domConverter.mapViewToDom(candidate)!;
-          const { bottom, top } = domElement.getBoundingClientRect();
-          const { marginBottom, marginTop } =
-            window.getComputedStyle(domElement);
-
-          const topBoundary = top - parseInt(marginTop);
-          const bottomBoundary = bottom + parseInt(marginBottom);
-
-          if (clientY >= topBoundary && clientY <= top) {
-            this.#insertParagraphBefore(candidate);
-
+          if (clientY <= top) {
             event.stop();
-            return;
-          } else if (clientY >= bottom && clientY <= bottomBoundary) {
-            this.#insertParagraphAfter(candidate);
 
-            event.stop();
+            this.#insertParagraphBefore(firstChild);
             return;
           }
         }
       }
-    );
+
+      if (root.childCount > 1) {
+        const lastChild = root.getChild(root.childCount - 1)!;
+
+        if (lastChild.is("containerElement")) {
+          const model = mapper.toModelElement(lastChild);
+          if (model && WoltlabMagicParagraph.blockModels.includes(model.name)) {
+            const domElement = domConverter.mapViewToDom(lastChild)!;
+            const { bottom } = domElement.getBoundingClientRect();
+
+            if (clientY >= bottom) {
+              event.stop();
+
+              this.#insertParagraphAfter(lastChild);
+              return;
+            }
+          }
+        }
+      }
+
+      // Find any block element whose margin is possibly being clicked on.
+      for (const candidate of this.#findPossibleBlocks()) {
+        const domElement = domConverter.mapViewToDom(candidate)!;
+        const { bottom, top } = domElement.getBoundingClientRect();
+        const { marginBottom, marginTop } = window.getComputedStyle(domElement);
+
+        const topBoundary = top - parseInt(marginTop);
+        const bottomBoundary = bottom + parseInt(marginBottom);
+
+        if (clientY >= topBoundary && clientY <= top) {
+          this.#insertParagraphBefore(candidate);
+
+          event.stop();
+          return;
+        } else if (clientY >= bottom && clientY <= bottomBoundary) {
+          this.#insertParagraphAfter(candidate);
+
+          event.stop();
+          return;
+        }
+      }
+    });
   }
 
   #insertParagraphBefore(element: ContainerElement): void {
+    const { mapper } = this.editor.editing;
+
     // Check if the adjacent element is already paragraph.
     let paragraph: Element | undefined = undefined;
     if (element.previousSibling && element.previousSibling.is("element", "p")) {
-      paragraph = this.editor.editing.mapper.toModelElement(
-        element.previousSibling
-      );
+      paragraph = mapper.toModelElement(element.previousSibling);
     } else {
       paragraph = undefined;
     }
@@ -137,7 +131,7 @@ export class WoltlabMagicParagraph extends Plugin {
         paragraph = writer.createElement("paragraph");
 
         const position = writer.createPositionBefore(
-          this.editor.editing.mapper.toModelElement(element)!
+          mapper.toModelElement(element)!
         );
         writer.insert(paragraph, position);
       }
@@ -147,12 +141,12 @@ export class WoltlabMagicParagraph extends Plugin {
   }
 
   #insertParagraphAfter(element: ContainerElement): void {
+    const { mapper } = this.editor.editing;
+
     // Check if the adjacent element is already paragraph.
     let paragraph: Element | undefined = undefined;
     if (element.nextSibling && element.nextSibling.is("element", "p")) {
-      paragraph = this.editor.editing.mapper.toModelElement(
-        element.nextSibling
-      );
+      paragraph = mapper.toModelElement(element.nextSibling);
     } else {
       paragraph = undefined;
     }
@@ -162,7 +156,7 @@ export class WoltlabMagicParagraph extends Plugin {
         paragraph = writer.createElement("paragraph");
 
         const position = writer.createPositionAfter(
-          this.editor.editing.mapper.toModelElement(element)!
+          mapper.toModelElement(element)!
         );
         writer.insert(paragraph, position);
       }
@@ -172,15 +166,17 @@ export class WoltlabMagicParagraph extends Plugin {
   }
 
   *#findPossibleBlocks(): IterableIterator<ContainerElement> {
-    const root = this.editor.editing.view.document.getRoot()!;
-    const range = this.editor.editing.view.createRangeIn(root);
+    const { mapper, view } = this.editor.editing;
+
+    const root = view.document.getRoot()!;
+    const range = view.createRangeIn(root);
     for (const value of range.getWalker({ ignoreElementEnd: true })) {
       const node = value.item;
       if (!node.is("containerElement")) {
         continue;
       }
 
-      const model = this.editor.editing.mapper.toModelElement(node);
+      const model = mapper.toModelElement(node);
 
       // Certain block elements such as `<ul>` or `<ol>` are inserted into the
       // view, but are not actually part of the model because there are only

--- a/plugins/ckeditor5-woltlab-magic-paragraph/src/woltlabmagicparagraph.ts
+++ b/plugins/ckeditor5-woltlab-magic-paragraph/src/woltlabmagicparagraph.ts
@@ -1,0 +1,125 @@
+/**
+ * Inserts extra buttons for BBCodes into the toolbar. Buttons have support for
+ * Font Awesome icons through the `<fa-icon>` element.
+ *
+ * @author Alexander Ebert
+ * @copyright 2001-2023 WoltLab GmbH
+ * @license LGPL-2.1-or-later
+ * @since 6.0
+ */
+
+import { Plugin } from "@ckeditor/ckeditor5-core";
+import {
+  ClickObserver,
+  Element,
+  type ViewDocumentClickEvent,
+} from "@ckeditor/ckeditor5-engine";
+import ContainerElement from "@ckeditor/ckeditor5-engine/src/view/containerelement";
+
+export class WoltlabMagicParagraph extends Plugin {
+  static readonly blockModels = ["blockQuote", "codeBlock", "spoiler", "table"];
+
+  static get pluginName() {
+    return "WoltlabMagicParagraph";
+  }
+
+  init() {
+    this.editor.editing.view.addObserver(ClickObserver);
+
+    const viewDocument = this.editor.editing.view.document;
+
+    this.listenTo<ViewDocumentClickEvent>(
+      viewDocument,
+      "click",
+      (event, data) => {
+        console.clear();
+
+        const { domEvent, domTarget, target } = data;
+
+        // Ignore any click that hits a paragraph or list item, because those
+        // are perfectly accessible anyway.
+        const elements = target.getAncestors();
+        elements.push(target);
+        for (const element of elements) {
+          if (element.is("element", "p") || element.is("element", "li")) {
+            return;
+          }
+        }
+
+        const { clientY } = domEvent;
+
+        // Find any block element whose margin is possibly being clicked on.
+        const { domConverter } = this.editor.editing.view;
+        for (const candidate of this.#findPossibleBlocks()) {
+          const domElement = domConverter.mapViewToDom(candidate)!;
+          const { bottom, top } = domElement.getBoundingClientRect();
+          const { marginBottom, marginTop } =
+            window.getComputedStyle(domElement);
+
+          const topBoundary = top + parseInt(marginTop);
+          const bottomBoundary = bottom + parseInt(marginBottom);
+
+          if (clientY <= topBoundary && clientY >= top) {
+            this.#insertParagraphBefore(candidate);
+
+            event.stop();
+            return;
+          } else if (clientY >= bottom && clientY <= bottomBoundary) {
+            this.#insertParagraphAfter(candidate);
+
+            event.stop();
+            return;
+          }
+        }
+      }
+    );
+  }
+
+  #insertParagraphBefore(element: ContainerElement): void {
+    console.log("insertParagraphBefore", element);
+  }
+
+  #insertParagraphAfter(element: ContainerElement): void {
+    console.log("insertParagraphAfter", element);
+    // Check if the adjacent element is already paragraph.
+    let paragraph: Element | undefined = undefined;
+    if (element.nextSibling && element.nextSibling.is("element", "p")) {
+      paragraph = this.editor.editing.mapper.toModelElement(
+        element.nextSibling
+      );
+    } else {
+      paragraph = undefined;
+    }
+
+    this.editor.model.change((writer) => {
+      if (paragraph === undefined) {
+        paragraph = writer.createElement("paragraph");
+
+        const position = writer.createPositionAfter(
+          this.editor.editing.mapper.toModelElement(element)!
+        );
+        writer.insert(paragraph, position);
+      }
+
+      writer.setSelection(paragraph, "end");
+    });
+  }
+
+  *#findPossibleBlocks(): IterableIterator<ContainerElement> {
+    const root = this.editor.editing.view.document.getRoot()!;
+    const range = this.editor.editing.view.createRangeIn(root);
+    for (const value of range.getWalker({ ignoreElementEnd: true })) {
+      const node = value.item;
+      if (node.is("containerElement")) {
+        const model = this.editor.editing.mapper.toModelElement(node)!;
+        // TODO: model is undefined when hitting the edge of the contents!
+        console.log(model, "is", model.name);
+        if (WoltlabMagicParagraph.blockModels.includes(model.name)) {
+          yield node;
+        }
+      }
+    }
+  }
+}
+
+export default WoltlabMagicParagraph;

--- a/plugins/ckeditor5-woltlab-magic-paragraph/src/woltlabmagicparagraph.ts
+++ b/plugins/ckeditor5-woltlab-magic-paragraph/src/woltlabmagicparagraph.ts
@@ -100,6 +100,13 @@ export class WoltlabMagicParagraph extends Plugin {
         const topBoundary = top - parseInt(marginTop);
         const bottomBoundary = bottom + parseInt(marginBottom);
 
+        if (clientY < topBoundary) {
+          // The click occurred somewhere above this element but outsides its
+          // margin. Elements are being transversed from top to bottom which
+          // means that we can safely stop searching at this point.
+          return;
+        }
+
         if (clientY >= topBoundary && clientY <= top) {
           this.#insertParagraphBefore(candidate);
 

--- a/plugins/ckeditor5-woltlab-magic-paragraph/src/woltlabmagicparagraph.ts
+++ b/plugins/ckeditor5-woltlab-magic-paragraph/src/woltlabmagicparagraph.ts
@@ -32,8 +32,6 @@ export class WoltlabMagicParagraph extends Plugin {
     view.addObserver(ClickObserver);
 
     this.listenTo<ViewDocumentClickEvent>(document, "click", (event, data) => {
-      console.clear();
-
       const { domEvent, target } = data;
 
       // Ignore any click that hits a paragraph or list item, because those

--- a/plugins/ckeditor5-woltlab-magic-paragraph/src/woltlabmagicparagraph.ts
+++ b/plugins/ckeditor5-woltlab-magic-paragraph/src/woltlabmagicparagraph.ts
@@ -56,7 +56,7 @@ export class WoltlabMagicParagraph extends Plugin {
           const { marginBottom, marginTop } =
             window.getComputedStyle(domElement);
 
-          const topBoundary = top + parseInt(marginTop);
+          const topBoundary = top - parseInt(marginTop);
           const bottomBoundary = bottom + parseInt(marginBottom);
 
           if (clientY >= topBoundary && clientY <= top) {

--- a/plugins/ckeditor5-woltlab-magic-paragraph/src/woltlabmagicparagraph.ts
+++ b/plugins/ckeditor5-woltlab-magic-paragraph/src/woltlabmagicparagraph.ts
@@ -13,10 +13,10 @@
 import { Plugin } from "@ckeditor/ckeditor5-core";
 import {
   ClickObserver,
-  Element,
+  type Element,
+  type ViewContainerElement,
   type ViewDocumentClickEvent,
 } from "@ckeditor/ckeditor5-engine";
-import ContainerElement from "@ckeditor/ckeditor5-engine/src/view/containerelement";
 
 export class WoltlabMagicParagraph extends Plugin {
   static readonly blockModels = ["blockQuote", "codeBlock", "spoiler", "table"];
@@ -122,7 +122,7 @@ export class WoltlabMagicParagraph extends Plugin {
     });
   }
 
-  #insertParagraphBefore(element: ContainerElement): void {
+  #insertParagraphBefore(element: ViewContainerElement): void {
     const { mapper } = this.editor.editing;
 
     // Check if the adjacent element is already paragraph.
@@ -147,7 +147,7 @@ export class WoltlabMagicParagraph extends Plugin {
     });
   }
 
-  #insertParagraphAfter(element: ContainerElement): void {
+  #insertParagraphAfter(element: ViewContainerElement): void {
     const { mapper } = this.editor.editing;
 
     // Check if the adjacent element is already paragraph.
@@ -172,7 +172,7 @@ export class WoltlabMagicParagraph extends Plugin {
     });
   }
 
-  *#findPossibleBlocks(): IterableIterator<ContainerElement> {
+  *#findPossibleBlocks(): IterableIterator<ViewContainerElement> {
     const { mapper, view } = this.editor.editing;
 
     const root = view.document.getRoot()!;


### PR DESCRIPTION
Automagically inserts a paragraph to allow users to easily type around certain block elements.

Activation conditions:
* The user clicked into the margin of certain block elements.
* Clicks happen at the very start of the editor before the first element and the first element is such a block element.
* Clicks happen inside the editor after the last element and the last element is a block element.

No action will be taken if there is an adjacent paragraph in the imaginary direction of the click that is a preceding paragraph for clicks at the top and vice versa.

Block elements (read: their models) that qualify for paragraphs around them are:
* `blockQuote`
* `codeBlock`
* `spoiler` (provided by `./plugins/ckeditor5-woltlab-spoiler`)
* `table`

The list of models is currently exposed through `WoltlabMagicParagraph.blockModels`.

Closes #16 