### PR TITLE
Export as amd module

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,10 @@ module.exports = (_env, argv) => {
     output: {
       path: path.resolve(__dirname, "dist"),
       filename: "ckeditor5.bundle.js",
-      library: "CKEditor5",
+      library: {
+        name: "ckeditor5-bundle",
+        type: "amd",
+      },
       //libraryTarget: 'amd',
     },
 


### PR DESCRIPTION
Export the bundle as AMD Module #91 
The previous import must be modified from

```TS
await import("ckeditor5-bundle");
...
await window.CKEditor5.create(element, configuration);
```
to

```TS
const CKEditor5 = await import("ckeditor5-bundle");
...
await CKEditor5.create(element, configuration);
```