### PR TITLE
Attachment/media inside a-tag

### DIFF
--- a/plugins/ckeditor5-woltlab-attachment/src/woltlabattachment.ts
+++ b/plugins/ckeditor5-woltlab-attachment/src/woltlabattachment.ts
@@ -60,6 +60,9 @@ export class WoltlabAttachment extends Plugin {
               if (img.is("element", "figure")) {
                 img = img.getChild(0);
               }
+              if (img.is("element", "a")) {
+                img = img.getChild(0);
+              }
 
               if (!img.is("element", "img")) {
                 return;

--- a/plugins/ckeditor5-woltlab-media/src/woltlabmedia.ts
+++ b/plugins/ckeditor5-woltlab-media/src/woltlabmedia.ts
@@ -83,6 +83,9 @@ export class WoltlabMedia extends Plugin {
               if (img.is("element", "figure")) {
                 img = img.getChild(0);
               }
+              if (img.is("element", "a")) {
+                img = img.getChild(0);
+              }
 
               if (!img.is("element", "img")) {
                 return;


### PR DESCRIPTION
Prevent media and attachments inside an a-tag from not adding the class and attribute to find them.