### PR TITLE
Font size upcast helper

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -35,6 +35,7 @@ import {
   WoltlabBlockQuote,
   WoltlabCode,
   WoltlabCodeBlock,
+  WoltlabFontSize,
   WoltlabHtmlEmbed,
   WoltlabImage,
   WoltlabMagicParagraph,
@@ -108,6 +109,7 @@ const defaultConfig: Core.EditorConfig = {
     WoltlabSpoiler.WoltlabSpoiler,
     WoltlabToolbarGroup.WoltlabToolbarGroup,
     WoltlabUpload.WoltlabUpload,
+    WoltlabFontSize.WoltlabFontSize,
   ],
 };
 

--- a/modules.ts
+++ b/modules.ts
@@ -47,3 +47,4 @@ export * as WoltlabSmiley from "./plugins/ckeditor5-woltlab-smiley/src";
 export * as WoltlabSpoiler from "./plugins/ckeditor5-woltlab-spoiler/src";
 export * as WoltlabToolbarGroup from "./plugins/ckeditor5-woltlab-toolbar-group/src";
 export * as WoltlabUpload from "./plugins/ckeditor5-woltlab-upload/src";
+export * as WoltlabFontSize from "./plugins/ckeditor5-woltlab-font-size/src";

--- a/plugins/ckeditor5-woltlab-font-size/package.json
+++ b/plugins/ckeditor5-woltlab-font-size/package.json
@@ -1,0 +1,6 @@
+{
+  "author": "WoltLab GmbH",
+  "license": "LGPL-2.1-or-later",
+  "main": "src/index.ts",
+  "private": true
+}

--- a/plugins/ckeditor5-woltlab-font-size/src/index.ts
+++ b/plugins/ckeditor5-woltlab-font-size/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @author Olaf Braun
+ * @copyright 2001-2024 WoltLab GmbH
+ * @license LGPL-2.1-or-later
+ * @since 6.0
+ */
+
+export { WoltlabFontSize } from "./woltlabfontsize";

--- a/plugins/ckeditor5-woltlab-font-size/src/woltlabfontsize.ts
+++ b/plugins/ckeditor5-woltlab-font-size/src/woltlabfontsize.ts
@@ -19,6 +19,10 @@ export class WoltlabFontSize extends Plugin {
   }
 
   init() {
+    if (!this.editor.plugins.has("FontSize")) {
+      return;
+    }
+
     const fontSizes = this.editor.config
       .get("fontSize")!
       .options!.map((size) => {

--- a/plugins/ckeditor5-woltlab-font-size/src/woltlabfontsize.ts
+++ b/plugins/ckeditor5-woltlab-font-size/src/woltlabfontsize.ts
@@ -1,0 +1,89 @@
+/**
+ * Creates an "upcast" converter that converts the font size from the view to the model.
+ * The converter finds the closest font size from the given list of font sizes.
+ *
+ * @author Olaf Braun
+ * @copyright 2001-2024 WoltLab GmbH
+ * @license LGPL-2.1-or-later
+ * @since 6.0
+ */
+
+import { Plugin } from "@ckeditor/ckeditor5-core";
+import { ViewElement } from "@ckeditor/ckeditor5-engine";
+
+export class WoltlabFontSize extends Plugin {
+  static readonly defaultFontSize = 15;
+
+  static get pluginName() {
+    return "WoltlabFontSize";
+  }
+
+  init() {
+    const fontSizes = this.editor.config
+      .get("fontSize")!
+      .options!.map((size) => {
+        if (size === "default") {
+          return WoltlabFontSize.defaultFontSize;
+        }
+        return size;
+      }) as Array<number>;
+
+    this.editor.conversion.for("upcast").elementToAttribute({
+      model: {
+        key: "fontSize",
+        value: (viewElement: ViewElement) => {
+          const fontSize = this.convertFontSizeToPx(
+            viewElement.getStyle("font-size"),
+          );
+          if (fontSize === undefined) {
+            return;
+          }
+          // Find the closest font size
+          return (
+            fontSizes.reduce((prev, curr) => {
+              return Math.abs(curr - fontSize) < Math.abs(prev - fontSize)
+                ? curr
+                : prev;
+            }) + "px"
+          );
+        },
+      },
+      view: {
+        name: "span",
+        styles: {
+          "font-size": /.*/,
+        },
+      },
+      converterPriority: "highest",
+    });
+  }
+
+  convertFontSizeToPx(fontSize: string | undefined): number | undefined {
+    if (fontSize === undefined) {
+      return undefined;
+    }
+
+    const regex = /^(\d*\.?\d+)(px|pt|em|%)$/;
+    const match = fontSize.match(regex);
+
+    if (!match) {
+      return undefined;
+    }
+
+    const value = parseFloat(match[1]);
+    const unit = match[2];
+
+    switch (unit) {
+      case "px":
+        return value;
+      case "pt":
+        return value * 1.33;
+      case "em":
+        return value * 16;
+      case "%":
+        return (value / 100) * WoltlabFontSize.defaultFontSize;
+    }
+  }
+}
+
+export default WoltlabFontSize;

--- a/plugins/ckeditor5-woltlab-font-size/src/woltlabfontsize.ts
+++ b/plugins/ckeditor5-woltlab-font-size/src/woltlabfontsize.ts
@@ -1,6 +1,6 @@
 /**
- * Creates an "upcast" converter that converts the font size from the view to the model.
- * The converter finds the closest font size from the given list of font sizes.
+ * Creates an "upcast" converter that converts the font size from the model to view.
+ * Converts the given font size to px and finds the closest font size from the given list of font sizes.
  *
  * @author Olaf Braun
  * @copyright 2001-2024 WoltLab GmbH


### PR DESCRIPTION
This upcast converts the given `font-size` to **px** from **pt**, **em** or **%** and use the closest available font size.

See also: https://www.woltlab.com/community/thread/304081-fontsize-formatierung-in-pt-geht-bei-bearbeitung-im-ckeditor-verloren-wunsch/