### PR TITLE
Fix when meta-code elements are inside a blockQuote element

### DIFF
--- a/plugins/ckeditor5-woltlab-metacode/src/woltlabmetacode.ts
+++ b/plugins/ckeditor5-woltlab-metacode/src/woltlabmetacode.ts
@@ -84,7 +84,7 @@ export class WoltlabMetacode extends Plugin {
           if (ancestors[ancestors.length - 1].name === "$root") {
             isBlockElement = true;
           } else if (parent.name === "blockQuote") {
-            // $text nodes only allowed on $block nodes
+            // Text nodes may only appear inside block nodes.
             isBlockElement = true;
           } else {
             for (const child of viewItem.getChildren()) {

--- a/plugins/ckeditor5-woltlab-metacode/src/woltlabmetacode.ts
+++ b/plugins/ckeditor5-woltlab-metacode/src/woltlabmetacode.ts
@@ -76,11 +76,15 @@ export class WoltlabMetacode extends Plugin {
             this.#serializedAttributesToString(attributes);
           const openingTag = writer.createText(`[${name}${attributeString}]`);
           const closingTag = writer.createText(`[/${name}]`);
+          const parent = modelCursor.parent;
 
           // Check if the BBCode appears to be a block element.
           let isBlockElement = false;
           const ancestors = modelCursor.getAncestors();
           if (ancestors[ancestors.length - 1].name === "$root") {
+            isBlockElement = true;
+          } else if (parent.name === "blockQuote") {
+            // $text nodes only allowed on $block nodes
             isBlockElement = true;
           } else {
             for (const child of viewItem.getChildren()) {


### PR DESCRIPTION
See: https://www.woltlab.com/community/thread/304742-zitat-funktion-fehlverhalten-bei-zitaten-mit-verlinkten-beiträgen/

`$text` nodes restricted to within `$block` nodes. A `blockQuote` is not a `$block` element.